### PR TITLE
fix: Fix improper handling of absolute and relative paths with sqlite;

### DIFF
--- a/.neuro/live.yaml
+++ b/.neuro/live.yaml
@@ -11,6 +11,6 @@ jobs:
   mlflow_server:
     action: gh:neuro-actions/mlflow@master
     args:
-      backend_store_uri: sqlite:///${{ volumes.mlflow_artifacts.mount }}/mlflow.db 
+      backend_store_uri: sqlite:////${{ volumes.mlflow_artifacts.mount }}/mlflow.db 
       artifacts_destination: ${{ volumes.mlflow_artifacts.mount }}
       volumes: "${{ to_json( [volumes.mlflow_artifacts.ref_rw] ) }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM continuumio/miniconda3:4.12.0
 
 ENV HOME="/root"
-WORKDIR ${HOME}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -19,11 +18,11 @@ RUN apt-get update && \
         curl \
         && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    cd $HOME && \
     git clone --depth=1 https://github.com/pyenv/pyenv.git .pyenv
 
 ENV PYENV_ROOT="${HOME}/.pyenv"
 ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
-
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --progress-bar=off -U --no-cache-dir -r /tmp/requirements.txt && \

--- a/action.yaml
+++ b/action.yaml
@@ -64,7 +64,7 @@ inputs:
       Extra parameters for `mlflow server` command invocation.
 
 job:
-  image: ghcr.io/neuro-inc/mlflow:v1.28.0
+  image: ghcr.io/neuro-inc/mlflow:pipelines
   name: ${{ inputs.job_name }}
   preset: ${{ inputs.preset }}
   http_port: ${{ inputs.port }}


### PR DESCRIPTION
The previous commit introduced a change to WORKDIR in Dockerfile, which uncovered a bug/feature where relative (`sqlite:///`) and absolute (`sqlite:////...`) sqlite paths were equivalent. Existing deployments that rely on `sqlite:///` working the same as `sqlite:////` were broken, but this PR will restore backward compatibility. 

We need to change instances of such improper use of sqlite URLs in web UI as well.